### PR TITLE
holding on to "self" in stop in case completion block removes our last reference

### DIFF
--- a/GSTween/GSTween.m
+++ b/GSTween/GSTween.m
@@ -186,12 +186,13 @@ NSString *const kGSTweenSpeed = @"speed";
 
 - (void)stop
 {
+    id retained = self;
     if (_completeBlock)
     {
         _completeBlock();
     }
     [_displayLink invalidate];
-    [self reset];
+    [retained reset];
 }
 
 - (void)pause


### PR DESCRIPTION
I was running into a bug with this. Simple fix. :)
